### PR TITLE
Dev

### DIFF
--- a/src/MurmurHash3.cpp
+++ b/src/MurmurHash3.cpp
@@ -91,8 +91,8 @@ FORCE_INLINE uint64_t fmix64 ( uint64_t k )
 
 //-----------------------------------------------------------------------------
 
-void MurmurHash3_x86_32 ( const void * key, int len,
-                          uint32_t seed, void * out )
+void MurmurHash3_x86_32 ( const void * key, const int len,
+                          const uint32_t seed, void * const out )
 {
   const uint8_t * data = (const uint8_t*)key;
   const int nblocks = len / 4;
@@ -148,7 +148,7 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 //-----------------------------------------------------------------------------
 
 void MurmurHash3_x86_128 ( const void * key, const int len,
-                           uint32_t seed, void * out )
+                           const uint32_t seed, void * const out )
 {
   const uint8_t * data = (const uint8_t*)key;
   const int nblocks = len / 16;
@@ -253,7 +253,7 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 //-----------------------------------------------------------------------------
 
 void MurmurHash3_x64_128 ( const void * key, const int len,
-                           const uint32_t seed, void * out )
+                           const uint32_t seed, void * const out )
 {
   const uint8_t * data = (const uint8_t*)key;
   const int nblocks = len / 16;

--- a/src/MurmurHash3.h
+++ b/src/MurmurHash3.h
@@ -26,11 +26,11 @@ typedef unsigned __int64 uint64_t;
 
 //-----------------------------------------------------------------------------
 
-void MurmurHash3_x86_32  ( const void * key, int len, uint32_t seed, void * out );
+void MurmurHash3_x86_32  ( const void * key, const int len, const uint32_t seed, void * const out );
 
-void MurmurHash3_x86_128 ( const void * key, int len, uint32_t seed, void * out );
+void MurmurHash3_x86_128 ( const void * key, const int len, const uint32_t seed, void * const out );
 
-void MurmurHash3_x64_128 ( const void * key, int len, uint32_t seed, void * out );
+void MurmurHash3_x64_128 ( const void * key, const int len, const uint32_t seed, void * const out );
 
 //-----------------------------------------------------------------------------
 

--- a/src/lookup3.cpp
+++ b/src/lookup3.cpp
@@ -1,4 +1,4 @@
-// lookup3 by Bob Jekins, code is public domain.
+// lookup3 by Bob Jenkins, code is public domain.
 
 #include "Platform.h"
 


### PR DESCRIPTION
Two fixes committed:

- `lookup3` author name was misspelled
- VC2013 noticed `MurmurHash3` function parameters sometimes used `const` but function declaration never used `const`