### PR TITLE
Ensure endianness is set correctly with GCC

### DIFF
--- a/src/PMurHash.c
+++ b/src/PMurHash.c
@@ -73,6 +73,12 @@ on big endian machines, or a byte-by-byte read if the endianess is unknown.
  * UNALIGNED_SAFE   Defined if READ_UINT32 works on non-word boundaries
  * ROTL32(x,r)      Rotate x left by r bits
  */
+	
+#if defined(__GNUC__)
+  #define __BIG_ENDIAN __ORDER_BIG_ENDIAN__
+  #define __LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+  #define __BYTE_ORDER __BYTE_ORDER__
+#endif
 
 /* Convention is to define __BYTE_ORDER == to one of these values */
 #if !defined(__BIG_ENDIAN)


### PR DESCRIPTION
GCC has standard predefined macros for byte order, documented at https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html. None of them are being used here, and there are no tests for 64-bit architectures like x86_64, so the result is failure to detect endianness when building with GCC on x86_64, which is a fairly standard setup.

This is not necessarily the cleanest-possible fix, especially since it does not clean up below comments about undocumented macros that GCC may or may not define, which do not seem to be accurate. The macro magic here could certainly stand some further cleanup.

(This code has just found its way into WebKit, which just updated its bundled copy of ANGLE, which bundles PMurHash.cpp. It seemed considerate to send upstreamable changes upstream. See https://trac.webkit.org/changeset/225412/webkit.)