### PR TITLE
Fixes Solaris build.

### DIFF
--- a/src/PMurHash.c
+++ b/src/PMurHash.c
@@ -91,9 +91,9 @@ on big endian machines, or a byte-by-byte read if the endianess is unknown.
 /* gcc 'may' define __LITTLE_ENDIAN__ or __BIG_ENDIAN__ to 1 (Note the trailing __),
  * or even _LITTLE_ENDIAN or _BIG_ENDIAN (Note the single _ prefix) */
 #if !defined(__BYTE_ORDER)
-  #if defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__==1 || defined(_LITTLE_ENDIAN) && _LITTLE_ENDIAN==1
+  #if defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__==1 || defined(_LITTLE_ENDIAN)
     #define __BYTE_ORDER __LITTLE_ENDIAN
-  #elif defined(__BIG_ENDIAN__) && __BIG_ENDIAN__==1 || defined(_BIG_ENDIAN) && _BIG_ENDIAN==1
+  #elif defined(__BIG_ENDIAN__) && __BIG_ENDIAN__==1 || defined(_BIG_ENDIAN)
     #define __BYTE_ORDER __BIG_ENDIAN
   #endif
 #endif


### PR DESCRIPTION
On Solaris /usr/include/sys/isa_defs.h defines _LITTLE_ENDIAN or _BIG_ENDIAN
without any value.

Following is build error from Firefox where it's used:

gmake[1]: Entering directory '/scratch/firefox/obj-x86_64-pc-solaris2.11/gfx/angle/targets/angle_common'
/usr/bin/g++ -std=gnu++14 -o PMurHash.o -c -I/scratch/firefox/obj-x86_64-pc-solaris2.11/dist/stl_wrappers -I/scratch/firefox/obj-x86_64-pc-solaris2.11/dist/system_wrappers -include /scratch/firefox/config/gcc_hidden.h -DNDEBUG=1 -DTRIMMED=1 -D__NDK_FPABI__= -Dconstexpr14= -DANGLE_SKIP_DXGI_1_2_CHECK -DANGLE_ENABLE_DEBUG_ANNOTATIONS -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DEGL_EGLEXT_PROTOTYPES -DGL_GLEXT_PROTOTYPES -DNOMINMAX -DNTDDI_VERSION=0x0A000000 -DUNICODE -D_ATL_NO_OPENGL -D_CRT_RAND_S -D_CRT_SECURE_NO_DEPRECATE -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SECURE_ATL -D_UNICODE -I/scratch/firefox/gfx/angle/targets/angle_common -I/scratch/firefox/obj-x86_64-pc-solaris2.11/gfx/angle/targets/angle_common -I/scratch/firefox/gfx/angle/checkout -I/scratch/firefox/gfx/angle/checkout/include -I/scratch/firefox/gfx/angle/checkout/out/gen -I/scratch/firefox/gfx/angle/checkout/out/gen/angle -I/scratch/firefox/gfx/angle/checkout/src -I/scratch/firefox/gfx/angle/checkout/src/common/third_party/base -I/scratch/firefox/obj-x86_64-pc-solaris2.11/dist/include -I/scratch/firefox/obj-x86_64-pc-solaris2.11/dist/include/nspr -I/scratch/firefox/obj-x86_64-pc-solaris2.11/dist/include/nss -fPIC -DMOZILLA_CLIENT -include /scratch/firefox/obj-x86_64-pc-solaris2.11/mozilla-config.h -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wall -Wempty-body -Wignored-qualifiers -Woverloaded-virtual -Wpointer-arith -Wsign-compare -Wtype-limits -Wunreachable-code -Wwrite-strings -Wno-invalid-offsetof -Wno-error=maybe-uninitialized -Wno-error=deprecated-declarations -Wno-error=array-bounds -Wno-error=free-nonheap-object -Wformat -fno-sized-deallocation -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fno-exceptions -fno-strict-aliasing -fno-rtti -fno-exceptions -fno-math-errno -pthread -pipe -g -O -fno-omit-frame-pointer -msse2  -MD -MP -MF .deps/PMurHash.o.pp   /scratch/firefox/gfx/angle/checkout/src/common/third_party/smhasher/src/PMurHash.cpp
/scratch/firefox/gfx/angle/checkout/src/common/third_party/smhasher/src/PMurHash.cpp:94:102: error: operator '&&' has no right operand
   #if defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__==1 || defined(_LITTLE_ENDIAN) && _LITTLE_ENDIAN==1
                                                                                                      ^
gmake[1]: *** [/scratch/firefox/config/rules.mk:1047: PMurHash.o] Error 1