### PR TITLE
smhasher: Set UNALIGNED_SAFE for 64-bit intel too.

### DIFF
--- a/src/PMurHash.c
+++ b/src/PMurHash.c
@@ -88,6 +88,12 @@ on big endian machines, or a byte-by-byte read if the endianess is unknown.
   #define UNALIGNED_SAFE
 #endif
 
+/* X86-64 */
+#if defined(_M_X64) || defined(__x86_64__)
+  #define __BYTE_ORDER __LITTLE_ENDIAN
+  #define UNALIGNED_SAFE
+#endif
+
 /* gcc 'may' define __LITTLE_ENDIAN__ or __BIG_ENDIAN__ to 1 (Note the trailing __),
  * or even _LITTLE_ENDIAN or _BIG_ENDIAN (Note the single _ prefix) */
 #if !defined(__BYTE_ORDER)


### PR DESCRIPTION
This is better for perf, and also happens to suppress a new clang warning:

  PMurHash.c(209,12): error: cast to smaller integer type 'long' from
    'const unsigned char *' is a Microsoft extension [-Werror,-Wmicrosoft-cast]
  int i = -(long)ptr & 3;
  ^~~~~~~~~

64-bit Windows is the only platform I know where long is smaller than
a pointer, and this code is in the !UNALIGNED_SAFE branch. So this patch
addresses the warning.

(Alternatively, we could insert a cast to (uintptr_t) before casting to
long, but the code seems to try to work before C99.)

https://crbug.com/1054220