### PR TITLE
Make fallthroughs explicit in MurmurHash3.cpp

### DIFF
--- a/src/MurmurHash3.cpp
+++ b/src/MurmurHash3.cpp
@@ -129,8 +129,8 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
   switch(len & 3)
   {
-  case 3: k1 ^= tail[2] << 16;
-  case 2: k1 ^= tail[1] << 8;
+  case 3: k1 ^= tail[2] << 16; [[fallthrough]];
+  case 2: k1 ^= tail[1] << 8; [[fallthrough]];
   case 1: k1 ^= tail[0];
           k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
   };
@@ -204,26 +204,26 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 
   switch(len & 15)
   {
-  case 15: k4 ^= tail[14] << 16;
-  case 14: k4 ^= tail[13] << 8;
+  case 15: k4 ^= tail[14] << 16; [[fallthrough]];
+  case 14: k4 ^= tail[13] << 8; [[fallthrough]];
   case 13: k4 ^= tail[12] << 0;
            k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
-
-  case 12: k3 ^= tail[11] << 24;
-  case 11: k3 ^= tail[10] << 16;
-  case 10: k3 ^= tail[ 9] << 8;
+           [[fallthrough]];
+  case 12: k3 ^= tail[11] << 24; [[fallthrough]];
+  case 11: k3 ^= tail[10] << 16; [[fallthrough]];
+  case 10: k3 ^= tail[ 9] << 8; [[fallthrough]];
   case  9: k3 ^= tail[ 8] << 0;
            k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
-
-  case  8: k2 ^= tail[ 7] << 24;
-  case  7: k2 ^= tail[ 6] << 16;
-  case  6: k2 ^= tail[ 5] << 8;
+           [[fallthrough]];
+  case  8: k2 ^= tail[ 7] << 24; [[fallthrough]];
+  case  7: k2 ^= tail[ 6] << 16; [[fallthrough]];
+  case  6: k2 ^= tail[ 5] << 8; [[fallthrough]];
   case  5: k2 ^= tail[ 4] << 0;
            k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
-
-  case  4: k1 ^= tail[ 3] << 24;
-  case  3: k1 ^= tail[ 2] << 16;
-  case  2: k1 ^= tail[ 1] << 8;
+           [[fallthrough]];
+  case  4: k1 ^= tail[ 3] << 24; [[fallthrough]];
+  case  3: k1 ^= tail[ 2] << 16; [[fallthrough]];
+  case  2: k1 ^= tail[ 1] << 8; [[fallthrough]];
   case  1: k1 ^= tail[ 0] << 0;
            k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
   };
@@ -293,22 +293,22 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 
   switch(len & 15)
   {
-  case 15: k2 ^= ((uint64_t)tail[14]) << 48;
-  case 14: k2 ^= ((uint64_t)tail[13]) << 40;
-  case 13: k2 ^= ((uint64_t)tail[12]) << 32;
-  case 12: k2 ^= ((uint64_t)tail[11]) << 24;
-  case 11: k2 ^= ((uint64_t)tail[10]) << 16;
-  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+  case 15: k2 ^= ((uint64_t)tail[14]) << 48; [[fallthrough]];
+  case 14: k2 ^= ((uint64_t)tail[13]) << 40; [[fallthrough]];
+  case 13: k2 ^= ((uint64_t)tail[12]) << 32; [[fallthrough]];
+  case 12: k2 ^= ((uint64_t)tail[11]) << 24; [[fallthrough]];
+  case 11: k2 ^= ((uint64_t)tail[10]) << 16; [[fallthrough]];
+  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8; [[fallthrough]];
   case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
            k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
-
-  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
-  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
-  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
-  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
-  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
-  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
-  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+           [[fallthrough]];
+  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56; [[fallthrough]];
+  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48; [[fallthrough]];
+  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40; [[fallthrough]];
+  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32; [[fallthrough]];
+  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24; [[fallthrough]];
+  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16; [[fallthrough]];
+  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8; [[fallthrough]];
   case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
            k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
   };


### PR DESCRIPTION
Allow the code to integrate nicely with codebases using clang (or GCC)'s `-Wimplicit-fallthrough` warning flag by marking fallthroughs as being intentional.